### PR TITLE
packaging(Formula): create formula for SnapX (#2)

### DIFF
--- a/Formula/snapx.rb
+++ b/Formula/snapx.rb
@@ -1,0 +1,56 @@
+class Snapx < Formula
+  desc "Screenshot tool that handles images, text, and video (fork of ShareX)"
+  homepage "https://github.com/BrycensRanch/SnapX"
+  url "https://github.com/BrycensRanch/SnapX/archive/40900c6.tar.gz"
+  version "0.2.1"
+  sha256 "a5f5525f508facb0097600554fc43fab9e9f1decc83517789df98a0ff2a5a20e"
+  license "GPL-3.0-or-later"
+  head "https://github.com/BrycensRanch/SnapX.git", branch: "develop"
+  # Uncomment to bump the package when still using the same SnapX version. Acts like the release field in snapx.spec
+  # revision 1
+
+  depends_on "dotnet" => :build
+  depends_on "git" => :build
+  depends_on "llvm" => :build
+  depends_on "ffmpeg@7"
+  # NativeAOT support
+  depends_on macos: :monterey
+
+  on_macos do
+    # Screenshotting on macOS is done via a Rust compat layer. We must compile it.
+    depends_on "rust" => :build
+  end
+  on_linux do
+    depends_on "dbus"
+    depends_on "libsm"
+    depends_on "libx11"
+    depends_on "libxcb"
+    depends_on "libxrandr"
+    depends_on "openssl@3"
+  end
+
+  def install
+    ENV["SKIP_MACOS_VERSION_CHECK"] = "1"
+    ENV["ELEVATION_NOT_NEEDED"] = "1"
+    system "./build.sh", "install", "--prefix", "/", "--dest-dir", "#{prefix}"
+  end
+
+  def caveats
+    <<~EOS
+      On Ubuntu, you need to run
+        sudo apt install -y libvlc-dev xdg-utils
+      On Fedora, you need to run
+        sudo dnf in -y vlc-devel xdg-utils
+      Additionally, SnapX hasn't been able to create the configuration file(s) it expects.
+      You should place it in the configuration directory that it expects.
+      On Linux, it's
+        ~/.config/SnapX
+      On macOS, it's
+        ~/Library/Application Support/SnapX
+      EOS
+  end
+
+  test do
+    system bin/"snapx", "--version"
+  end
+end


### PR DESCRIPTION
* chore: update `.gitignore` to include macOS specific files



* build: create formula

* style: formatting issues

* fix: add version stanza

* fix: oops

* fix: resolve syntax errors and declare explicit dependencies for Linux and macOS

- Bumps SnapX version to `0.2.1` to fix building in Homebrew environment. Previously, the build system, when installing, would try to elevate to root to install files in directories that it believed were privileged.
- Add X11-related dependencies explicitly for Linux.
- Add DBus as a dependency for Linux.
- Add OpenSSL as a dependency for Linux.
- Mention xdg-utils not being packaged as a caveat for Linux.
- Mark LLVM toolchain as a build-time dependency, not a general dependency.
- Only try to use `dotnet-sdk` Cask on macOS.
- Add Xcode dependency for macOS.
- Removed distro detection.

* build: use dotnet formula exclusively removing dotnet-sdk Cask

On my macOS Sequoia test machine, formulas are NOT allowed to have casks as dependencies?

* build: remove dependency on FULL XCode.app install

NativeAOT only needs XCode Command Line Tools, and that's installed automatically when you install Homebrew.

* build: remove unnecessary zlib dependency in caveats

* build: do not quote prefix to prevent build fail on macOS

* build: upgrade SnapX commit to one with working install logic for macOS

* build: bump SnapX for working install command

* chore: add `brew test` for SnapX formula

* Update test-snapx.yml

* Update test-snapx.yml

* Update test-snapx.yml

* Update test-snapx.yml

* Update test-snapx.yml

* Update test-snapx.yml

* Update test-snapx.yml

* Rename Formula/s/snapx.rb to Formula/snapx.rb

* Update test-snapx.yml

* style: brew style and move to proper directory

* style: brew style

* style: brew style

* style:

* style: brew style

* style: brew style

* style: brew style

* style: brew style

* style: brew style

* revert "style: brew style"



* style: revert `style: brew style`



* chore: remove test-snapx workflow

Why was this here?



* style: run brew style



* fix: bump SnapX commit to fix broken binaries on install on macOS



---------